### PR TITLE
Fix desktop symbol name and exec argument for non-preview version

### DIFF
--- a/powershell-lts/snap/gui/powershell.desktop
+++ b/powershell-lts/snap/gui/powershell.desktop
@@ -1,7 +1,6 @@
-
 [Desktop Entry]
-Name=PowerShell Preview
-Exec=powershell-preview
+Name=PowerShell
+Exec=powershell
 Type=Application
 Terminal=true
 Categories=ConsoleOnly;System

--- a/powershell-preview/snap/gui/powershell.desktop
+++ b/powershell-preview/snap/gui/powershell.desktop
@@ -1,4 +1,3 @@
-
 [Desktop Entry]
 Name=PowerShell Preview
 Exec=powershell-preview

--- a/powershell-stable/snap/gui/powershell.desktop
+++ b/powershell-stable/snap/gui/powershell.desktop
@@ -1,7 +1,6 @@
-
 [Desktop Entry]
-Name=PowerShell Preview
-Exec=powershell-preview
+Name=PowerShell
+Exec=powershell
 Type=Application
 Terminal=true
 Categories=ConsoleOnly;System


### PR DESCRIPTION
### What is it about?
After installing powershell from the "latest/stable" channel, the created desktop entry is "PowerShell Preview" and when launching fails with an error.

### What is the fix?
Update `.desktop` file to use the correct name for each snap and add the `Exec` argument with the PowerShell command.