### PR TITLE
fix: non-writable global user profile #14

### DIFF
--- a/powershell-lts/patches/global-profiles-stores-in-etc.patch
+++ b/powershell-lts/patches/global-profiles-stores-in-etc.patch
@@ -1,0 +1,24 @@
+diff --git a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+index 439826984..d08d21f86 100644
+--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
++++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+@@ -255,16 +255,9 @@ namespace System.Management.Automation
+         /// <returns>The base path for all users profiles.</returns>
+         private static string GetAllUsersFolderPath(string shellId)
+         {
+-            string folderPath = string.Empty;
+-            try
+-            {
+-                folderPath = Utils.GetApplicationBase(shellId);
+-            }
+-            catch (System.Security.SecurityException)
+-            {
+-            }
+-
+-            return folderPath;
++            string folderPath = Environment.GetEnvironmentVariable("POWERSHELL_COMMON_APPLICATION_DATA");
++            if (!string.IsNullOrEmpty(folderPath)) return folderPath;
++            return "/etc/opt/powershell";
+         }
+         #endregion GetProfileCommands
+ 

--- a/powershell-preview/patches/global-profiles-stores-in-etc.patch
+++ b/powershell-preview/patches/global-profiles-stores-in-etc.patch
@@ -1,0 +1,24 @@
+diff --git a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+index 003625791..18dbda34f 100644
+--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
++++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+@@ -233,16 +233,9 @@ namespace System.Management.Automation
+         /// <returns>The base path for all users profiles.</returns>
+         private static string GetAllUsersFolderPath(string shellId)
+         {
+-            string folderPath = string.Empty;
+-            try
+-            {
+-                folderPath = Utils.GetApplicationBase(shellId);
+-            }
+-            catch (System.Security.SecurityException)
+-            {
+-            }
+-
+-            return folderPath;
++            string folderPath = Environment.GetEnvironmentVariable("POWERSHELL_COMMON_APPLICATION_DATA");
++            if (!string.IsNullOrEmpty(folderPath)) return folderPath;
++            return "/etc/opt/powershell";
+         }
+         #endregion GetProfileCommands
+ 

--- a/powershell-stable/patches/global-profiles-stores-in-etc.patch
+++ b/powershell-stable/patches/global-profiles-stores-in-etc.patch
@@ -1,0 +1,24 @@
+diff --git a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+index 003625791..18dbda34f 100644
+--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
++++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+@@ -233,16 +233,9 @@ namespace System.Management.Automation
+         /// <returns>The base path for all users profiles.</returns>
+         private static string GetAllUsersFolderPath(string shellId)
+         {
+-            string folderPath = string.Empty;
+-            try
+-            {
+-                folderPath = Utils.GetApplicationBase(shellId);
+-            }
+-            catch (System.Security.SecurityException)
+-            {
+-            }
+-
+-            return folderPath;
++            string folderPath = Environment.GetEnvironmentVariable("POWERSHELL_COMMON_APPLICATION_DATA");
++            if (!string.IsNullOrEmpty(folderPath)) return folderPath;
++            return "/etc/opt/powershell";
+         }
+         #endregion GetProfileCommands
+ 


### PR DESCRIPTION
## Summary

PowerShell should search in a dedicated directory (other than the installation directory) for the all-users profile to adhere to the [Filesystem Hierarchy Standard (FHS)](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html).

## Context

Currently the all-users profiles are stored in the installation directory. Unix-based systems and derivatives mostly follow recommendations of the FHS. The FHS recommends to place configuration files into the `/etc` directory.

For example, here are the locations of the system wide configuration files of other popular shells:
- [bash(1)](https://manpages.ubuntu.com/manpages/en/man1/bash.1.html): `/etc/bash.bashrc` (Debian/Ubuntu) or `/etc/bashrc` (RedHat/Fedora)
- [zsh(1)](https://manpages.ubuntu.com/manpages/en/man1/zsh.1.html):  `/etc/zshrc`
- [fish(1)](https://manpages.ubuntu.com/manpages/en/man1/fish.1.html): `/etc/fish/config.fish`

I took inspiration from where NuGet is locating its system-wide configuration, see [NuGet config file locations](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#config-file-locations-and-uses):

This commit introduces the environment variable `POWERSHELL_COMMON_APPLICATION_DATA`. If this variable is neither null nor empty, then this location is used; otherwise PowerShell uses `/etc/opt/powershell`.

Fixes: #14

I am currently working on upstreaming a similar patch, see https://github.com/PowerShell/PowerShell/pull/25748

> ![NOTE]
> This PR is based on PR #15. It needs to merge first. For easier readability of the diff I set the merge target to #15. Reset this to main once #15 is merged.