### PR TITLE
Run `test` and `publish` jobs on self-hosted runners

### DIFF
--- a/.github/workflows/template-build.yaml
+++ b/.github/workflows/template-build.yaml
@@ -8,7 +8,7 @@ on:
         type: string
 
 jobs:
-  build-powershell-snap:
+  build:
     strategy:
       matrix:
         os:

--- a/.github/workflows/template-publish.yaml
+++ b/.github/workflows/template-publish.yaml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         os:
@@ -20,14 +19,15 @@ jobs:
           - [self-hosted, linux, large, noble, arm64]
           - [self-hosted, linux, noble, s390x]
           - [self-hosted, linux, noble, ppc64el]
+    runs-on: ${{ matrix.os }}
     environment:
       name: ${{ inputs.release }}
     steps:
-      - uses: actions/checkout@v4
-        id: checkout
-      - name: Publish PowerShell Snaps
-        id: publish
-        uses: ./.github/actions/publish-powershell-snap
-        with:
-          release: ${{ inputs.release }}
-          store-token: ${{ secrets.SNAP_STORE_TOKEN }}
+    - uses: actions/checkout@v4
+      id: checkout
+    - name: Publish PowerShell Snaps
+      id: publish
+      uses: ./.github/actions/publish-powershell-snap
+      with:
+        release: ${{ inputs.release }}
+        store-token: ${{ secrets.SNAP_STORE_TOKEN }}

--- a/.github/workflows/template-test.yaml
+++ b/.github/workflows/template-test.yaml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         os:
@@ -17,11 +16,12 @@ jobs:
           - [self-hosted, linux, large, noble, arm64]
           - [self-hosted, linux, noble, s390x]
           - [self-hosted, linux, noble, ppc64el]
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-        id: checkout
-      - name: Test PowerShell Snaps
-        id: test
-        uses: ./.github/actions/test-powershell-snap
-        with:
-          release: ${{ inputs.release }}
+    - uses: actions/checkout@v4
+      id: checkout
+    - name: Test PowerShell Snaps
+      id: test
+      uses: ./.github/actions/test-powershell-snap
+      with:
+        release: ${{ inputs.release }}


### PR DESCRIPTION
This PR fixes a mistake on the `test` and `publish` jobs, which were running on the GitHub runner `ubuntu-latest` instead of the self-hosted arch-specific runners.